### PR TITLE
added conda.enabled = true to config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -141,14 +141,16 @@ profiles {
     // engines
     conda { 
         conda {
+            enabled = true
             cacheDir = params.conda_cache_dir
         }
         includeConfig 'configs/conda.config'
     }
     mamba { 
         conda {
-            cacheDir = params.conda_cache_dir
+            enabled = true
             useMamba = true
+            cacheDir = params.conda_cache_dir
         }
         includeConfig 'configs/conda.config'
     }
@@ -175,6 +177,7 @@ profiles {
                	cpus = params.max_cores
         }
         conda {
+            enabled = true
             cacheDir = params.conda_cache_dir
         }
         params.cloudProcess = false


### PR DESCRIPTION
explicitly enabling is required since Nextflow version 22.07