### PR TITLE
Feature filter indels

### DIFF
--- a/CoVpipe2.nf
+++ b/CoVpipe2.nf
@@ -6,7 +6,7 @@ nextflow.enable.dsl=2
 if (params.help) { exit 0, helpMSG() }
 
 // parameter sanity check
-Set valid_params = ['cores', 'max_cores', 'memory', 'help', 'profile', 'workdir', 'fastq', 'list', 'mode', 'run_id', 'reference', 'ref_genome', 'ref_annotation', 'adapter', 'fastp_additional_parameters', 'kraken', 'kraken_db_custom', 'taxid', 'read_linage', 'lcs_ucsc_version', 'lcs_ucsc_predefined', 'lcs_ucsc_update', 'lcs_ucsc_downsampling', 'lcs_variant_groups', 'lcs_cutoff', 'isize_filter', 'primer_bed', 'primer_bedpe', 'primer_version', 'bamclipper_additional_parameters', 'vcount', 'frac', 'cov', 'vois', 'var_mqm', 'var_sap', 'var_qual', 'cns_min_cov', 'cns_gt_adjust', 'update', 'pangolin_docker_default', 'nextclade_docker_default', 'pangolin_conda_default', 'nextclade_conda_default', 'nextclade_dataset_name', 'nextclade_dataset_tag', 'output', 'reference_dir', 'read_dir', 'mapping_dir', 'variant_calling_dir', 'consensus_dir', 'linage_dir', 'report_dir', 'rki_dir', 'runinfo_dir', 'singularity_cache_dir', 'conda_cache_dir', 'databases', 'publish_dir_mode', 'cloudProcess', 'cloud-process']
+Set valid_params = ['cores', 'max_cores', 'memory', 'help', 'profile', 'workdir', 'fastq', 'list', 'mode', 'run_id', 'reference', 'ref_genome', 'ref_annotation', 'adapter', 'fastp_additional_parameters', 'kraken', 'kraken_db_custom', 'taxid', 'read_linage', 'lcs_ucsc_version', 'lcs_ucsc_predefined', 'lcs_ucsc_update', 'lcs_ucsc_downsampling', 'lcs_variant_groups', 'lcs_cutoff', 'isize_filter', 'primer_bed', 'primer_bedpe', 'primer_version', 'bamclipper_additional_parameters', 'vcount', 'frac', 'cov', 'vois', 'var_mqm', 'var_sap', 'var_qual', 'cns_min_cov', 'cns_gt_adjust', 'cns_indel_filter', 'update', 'pangolin_docker_default', 'nextclade_docker_default', 'pangolin_conda_default', 'nextclade_conda_default', 'nextclade_dataset_name', 'nextclade_dataset_tag', 'output', 'reference_dir', 'read_dir', 'mapping_dir', 'variant_calling_dir', 'consensus_dir', 'linage_dir', 'report_dir', 'rki_dir', 'runinfo_dir', 'singularity_cache_dir', 'conda_cache_dir', 'databases', 'publish_dir_mode', 'cloudProcess', 'cloud-process']
 def parameter_diff = params.keySet() - valid_params
 if (parameter_diff.size() != 0){
     exit 1, "ERROR: Parameter(s) $parameter_diff is/are not valid in the pipeline!\n"
@@ -441,6 +441,10 @@ def helpMSG() {
     --cns_gt_adjust          Minimum fraction of reads supporting a variant which leads to an explicit call of this 
                                  variant (genotype adjustment). The value has to be greater than 0.5 but not greater than 1. 
                                  To turn genotype adjustment off, set the value to 0. [default: $params.cns_gt_adjust]
+    --cns_indel_filter       Minimum fraction of reads supporting an indel which leads to an integration to the consensus sequence.
+                                 Low frequency indels can be false positives introducing frameshifts. Since the IUPAC code is not able
+                                 to model a base-or-gap case, those indels would be integrated in the IUPAC and masked consensus.
+                                 To turn indel filtering off, set the value to 0. [default: $params.cns_indel_filter]
 
     ${c_yellow}Updated for linage assignment and mutation calling:${c_reset}
     --update                   Update pangolin and nextclade [default: $params.update]

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ Robert Koch Institute, MF1 Bioinformatics
     --cns_gt_adjust          Minimum fraction of reads supporting a variant which leads to an explicit call of this 
                                  variant (genotype adjustment). The value has to be greater than 0.5 but not greater than 1. 
                                  To turn genotype adjustment off, set the value to 0. [default: 0.9]
+    --cns_indel_filter       Minimum fraction of reads supporting an indel which leads to an integration to the consensus sequence.
+                                 Low frequency indels can be false positives introducing frameshifts. Since the IUPAC code is not able
+                                 to model a base-or-gap case, those indels would be integrated in the IUPAC and masked consensus.
+                                 To turn indel filtering off, set the value to 0. [default: 0.6]
 
     Updated for linage assignment and mutation calling:
     --update                   Update pangolin and nextclade [default: false]

--- a/bin/adjust_gt.py
+++ b/bin/adjust_gt.py
@@ -22,13 +22,6 @@ def parse_args(CMD=None):
     parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
     return parser.parse_args(CMD)
 
-def get_cmd_from_snake(snakemake):
-    cmd = ["-o", snakemake.output[0],
-           "--vf", snakemake.params.frac,
-          "--gz", snakemake.input[0]]
-    cmd = [str(arg) for arg in cmd]
-    return cmd
-
 # open file handles considering compression state
 def get_filehandle(in_fname, gz):
     if not gz:
@@ -119,11 +112,8 @@ def bgzip_outname(_file, outfile=None):
             ret = bg_proc.wait() 
                 
 def main(CMD=None):
-        args = parse_args(CMD)
-        process(args.vcf, args.o, args.vf, args.ao, args.dp, args.gt, args.gz)
+    args = parse_args(CMD)
+    process(args.vcf, args.o, args.vf, args.ao, args.dp, args.gt, args.gz)
 
 if __name__ == "__main__":
-        CMD = None
-        if "snakemake" in globals(): 
-            CMD = get_cmd_from_snake(snakemake)
-        main(CMD=CMD)
+    main()

--- a/bin/filter_indels.py
+++ b/bin/filter_indels.py
@@ -55,7 +55,7 @@ def process(in_fname, out_fname, min_vf, ao_tag="AO", dp_tag="DP", type_tag="TYP
                 #find TYPE
                 info = { i.split('=')[0]: i.split('=')[1] for i in fields[7].split(";") }
 
-                if not ( 'ins' in info[type_tag] or 'del' in info[type_tag] ):
+                if not ( 'ins' in info[type_tag] or 'del' in info[type_tag] or 'complex' in info[type_tag] ):
                     # not a indel
                     outhandle.write(line)
                     continue

--- a/bin/filter_indels.py
+++ b/bin/filter_indels.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#author: Marie Lataretu (Robert Koch Institute, MF-1, lataretum@rki.de)
+#adapted from: Stephan Fuchs (Robert Koch Institute, MF-1, fuchss@rki.de)
+
+VERSION = "0.0.9"
+import os
+import argparse
+import subprocess
+import re
+import sys
+import gzip
+
+def parse_args(CMD=None):
+    parser = argparse.ArgumentParser(prog="rename_in_gff3.py", description="changes genotype in VCFs", )
+    parser.add_argument('vcf', metavar="FILE", help="vcf file", type=str)
+    parser.add_argument('--ao', metavar="STR", help="tag for read count supporting the respective variant (default: AO)", type=str, default="AO")
+    parser.add_argument('--dp', metavar="STR", help="tag for total read count at the repsective position (default: DP)", type=str, default="DP")
+    parser.add_argument('--tt', metavar="STR", help="tag for type (default: TYPE)", type=str, default="TYPE")
+    parser.add_argument('-o', help="output file (will be overwritten!)", type=str, required=True)
+    parser.add_argument('--gz', help="bgzip compressed input", action="store_true")
+    parser.add_argument('--vf', metavar="FLOAT", help="minimal variant fraction to set include an indel into the consensus (default: 0.9)", type=float, default=0.9)
+    parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
+    return parser.parse_args(CMD)
+
+# open file handles considering compression state
+def get_filehandle(in_fname, gz):
+    if not gz:
+        inhandle = open(in_fname, "r")
+    else:
+        inhandle = gzip.open(in_fname, "rt")
+    return inhandle
+                
+def process(in_fname, out_fname, min_vf, ao_tag="AO", dp_tag="DP", type_tag="TYPE", gz=False):
+    #sanity checks
+    if min_vf <= 0:
+        sys.exit("error: min_vf has to be greater than 0")
+    out_gz = out_fname.endswith(".gz")
+    intermediate = re.sub("\.gz$","", out_fname)
+
+    #regex generation
+    ao_pattern = re.compile(r"(?:^|\t|;)" + re.escape(ao_tag) + "=([0-9,]+)(?:$|\t|;)")
+    dp_pattern = re.compile(r"(?:^|\t|;)" + re.escape(dp_tag) + "=([0-9]+)(?:$|\t|;)")
+
+    with get_filehandle(in_fname, gz) as inhandle: 
+        with open(intermediate, "w") as outhandle: 
+            for l, line in enumerate(inhandle):
+                #skip empty or comment lines
+                if len(line.strip()) == 0 or line.startswith("#"):
+                    outhandle.write(line)
+                    continue
+
+                fields = line.split("\t")
+                
+                #find TYPE
+                info = { i.split('=')[0]: i.split('=')[1] for i in fields[7].split(";") }
+
+                if not ( 'ins' in info[type_tag] or 'del' in info[type_tag] ):
+                    # not a indel
+                    outhandle.write(line)
+                    continue
+
+                #find ao and dp
+                ao = ao_pattern.findall(fields[7])
+                dp = dp_pattern.findall(fields[7])
+                
+                if len(ao) > 1:
+                    sys.exit("error: multiple occurences of " + ao_tag + " tag in line " + str(l+1))
+                if len(dp) > 1:
+                    sys.exit("error: multiple occurences of " + dp_tag + " tag in line " + str(l+1))
+                
+                #calc fractions and check threshold
+                fracs = [int(x)/int(dp[0]) for x in ao[0].split(",")]
+                m = max(fracs)
+                
+                if m > min_vf:
+                    outhandle.write(line)
+                    continue
+        if out_gz:
+            bgzip_outname(intermediate, out_fname)
+        
+def bgzip_outname(_file, outfile=None):
+    if outfile is not None:
+        with open(outfile, "wb") as out_fh:
+            with subprocess.Popen(["bgzip", _file, "-c"], 
+                                   stdout=out_fh) as bg_proc:
+                ret = bg_proc.wait() 
+        os.remove(_file)  
+    else:
+        with subprocess.Popen(["bgzip", _file], 
+                               stderr=subprocess.PIPE) as bg_proc:
+            out, err = bg_proc.communicate()
+            ret = bg_proc.wait() 
+                
+def main(CMD=None):
+    args = parse_args(CMD)
+    process(args.vcf, args.o, args.vf, args.ao, args.dp, args.tt, args.gz)
+
+if __name__ == "__main__":
+    main()

--- a/modules/adjust_variants.nf
+++ b/modules/adjust_variants.nf
@@ -18,3 +18,24 @@ process adjust_gt {
     touch ${name}.filtered.gt_adjust.vcf
     """
 }
+
+process filter_indels {
+    label 'python'
+    label 'smallTask'
+
+    input:
+    tuple val(name), path(vcf)
+    val(indel_threshold)
+
+    output:
+    tuple val(name), path("${name}.filtered.gt_adjust.filtered_indels.vcf")
+
+    script:
+    """
+    filter_indels.py --vf ${indel_threshold} --gz ${vcf} -o ${name}.filtered.gt_adjust.filtered_indels.vcf
+    """
+    stub:
+    """
+    touch ${name}.filtered.gt_adjust.filtered_indels.vcf
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,6 +69,7 @@ params {
     // consensus generation
     cns_min_cov = 20
     cns_gt_adjust = 0.9
+    cns_indel_filter = 0.6
 
     // update settings and default container
     update = false
@@ -90,7 +91,6 @@ params {
     linage_dir = '05-Linages_Mutations'
     rki_dir = '06-RKI-summary'
     report_dir = 'Report'
-    rki_dir = '06-RKI-summary'
     runinfo_dir = 'X.Pipeline-Runinfo'
 
     // location for engines' cache


### PR DESCRIPTION
- indels can be filtered before consensus generation by their fraction
- can prevent frameshifts, because IUPAC can not model base-or-gap cases and always includes the indel
- activated for event types `ins`, `del` and `complex`